### PR TITLE
Minor typos and clarifications

### DIFF
--- a/1890rules-en-translation.tex
+++ b/1890rules-en-translation.tex
@@ -640,7 +640,7 @@ Kinki, \autoref{kinki}]
 
 \subsection{Company closure}
 Private companies will be closed at the beginning of Phase 4
-(exceptions: Hankan Electric Railway, C8.4, D8.5: Osaka City Tramway).
+(exceptions: Hankai Tramway (see scenarios C8.1, D8.1): Osaka Municipal Electric Railway).
 
 A public company closes when its stock price token enters the closed
 space on the stock price table. The closed company's stock
@@ -781,8 +781,8 @@ card to the next player in clockwise order.
 
 \subsubsection{Available Railway Companies and Auctioned Companies}
 The only railway companies that players can buy are the companies at
-the very beginning of the list of companies. The companies listed
-after that will are auctionable railway companies.
+the very beginning of the list of companies. All the companies (Private and Minor) listed
+after that are auctionable railway companies.
 
 \subsubsection{Purchase Available Railway Company}
 The active player may buy the purchaseable company at face value, then
@@ -905,7 +905,7 @@ A minor or public company's operating round turn consists of the following steps
 \item Place a new station token. (Optional, public company only)
 \item Run trains for revenue.
 \item Public companies pay dividends or withhold. Minor companies will
-  pay dividends.
+  pay 50% dividends.
 \item Move the stock price token in the stock price table. (Public company only)
 \item Buy trains. (Optional)
 \end{enumerate}
@@ -1196,7 +1196,7 @@ purchase late private companies during their turn in a regular stock
 round (not an initial stock round). Each late private company owned by
 the player counts as one certificate toward the certificate
 limit. Late private companies may not be sold during the game. At the
-beginng of each operating round, the player which owns the late
+beginning of each operating round, the player which owns the late
 private company receives the dividend printed on its certificate. Late
 private companies do not close during the game.
 
@@ -1380,7 +1380,7 @@ win. Count the following towards personal assets:
 \begin{itemize}
 \item On-hand cash held by players
 \item Shares valued by their price on the stock price table
-\item The face value of private companies, a minor companies, and late
+\item The face value of private companies, minor companies, and late
   private companies
 \end{itemize}
 


### PR DESCRIPTION
Various typos and clarifications. Need to clarify the Late Private Company details in appendix C to match.